### PR TITLE
Delay construction of Panama and Kiel Canals

### DIFF
--- a/HPM/decisions/Canals.txt
+++ b/HPM/decisions/Canals.txt
@@ -16,7 +16,7 @@ political_decisions = {
 		
 		allow = {
 			invention = machine_tools
-			invention = nitroglycerin
+			invention = dynamite
 			iron_steamers = 1
 			OR = {
 				money = 50000
@@ -200,7 +200,7 @@ political_decisions = {
 		}
 		allow = {
 			invention = machine_tools
-			invention = nitroglycerin
+			invention = trinitrotoluene
 			invention = prophylaxis_against_malaria
 			iron_steamers = 1
 			1723 = {

--- a/HPM/events/GreatPowers.txt
+++ b/HPM/events/GreatPowers.txt
@@ -1198,12 +1198,13 @@ country_event = {
 		NOT = {
 			has_global_flag = tutankhamun_found
 		}
+		year = 1900
 	}
 	
 	major = yes
 	
 	mean_time_to_happen = {
-		months = 2000
+		months = 265
 	}
 	
 	option = {


### PR DESCRIPTION
Using new inventions to delay the construction of the Panama and Kiel Canals to closer to their actual construction dates (1904 and 1887 respectively).