### PR TITLE
Dismantlement properly looks for Ghana overlord

### DIFF
--- a/HPM/events/GreatWar_Events.txt
+++ b/HPM/events/GreatWar_Events.txt
@@ -11734,7 +11734,7 @@ country_event = {
 		
 		random_country = {
 			limit = {
-				THIS = { has_country_flag = ghana_organized }
+				THIS = { has_country_flag = ghana_master }
 				tag = FROM
 				any_owned_province = { is_core = GHN }
 			}


### PR DESCRIPTION
Fix what looks like a straightforward typo: `ghana_organized` is never
used as a country flag but rather as a global flag, whereas all other
colonial dismantlement events refer to the `ghana_master` country flag.
(Likewise country flags `sudan_master`, `angola_master`, etc.)

This change has not been tested.