### PR TITLE
Add random variation to AI choice of NV

### DIFF
--- a/HPM/decisions/NV_Changes.txt
+++ b/HPM/decisions/NV_Changes.txt
@@ -45,6 +45,37 @@ political_decisions = {
 		ai_will_do = { factor = 0 }
 	}
 
+	# All five national values are designed to be picked at random by eligible AI countries. Normally this would be
+	# achieved through e.g. a `random_list` command. Unfortunately this can be tricky to get right when done from a
+	# decision as all countries activating the same decision on the same day can get identical results.
+	#
+	# Instead we rely on the `ai_will_do` factor which, for a decision, is the chance (should all requirements be met)
+	# that the AI activates it on any given day. However because the engine processes available decisions top to bottom
+	# (order being the same as in the decision file) the actual factors have to be computed carefully.
+	#
+	# For instance if the first processed decision has weight A, the practical factor B' of the second decision
+	# should be the original weight B but rescaled over the smaller probability space in the outcome that the preceding
+	# decision was not activated, which has complement probablity (1 - A):
+	#
+	#     B' = B / (1 - A)
+	#
+	# This generalises to multiple successive decisions. Notably it leads to a last practical factor of 1, such that
+	# whenever it is the day for an AI country to pick a new national value they are guaranteed to choose (as long as no
+	# other higher priority decision is available to be taken).
+	#
+	# The following table summarises the desired random weights & probabilities, as well as some of the computation
+	# details leading to the final practical factor:
+	#
+	# National value | Weight | Probability | Cumulative Rescale Divisor (CRD) | Practical Factor (Probability over CRD)
+	# ---------------+--------+-------------+----------------------------------+----------------------------------------
+	# Order          |      1 |         20% |                                1 |                                  0.200
+	# Productivity   |      1 |         20% |                              0.8 |                                  0.250
+	# Autocracy      |      1 |         20% |                              0.6 |                                  0.333
+	# Liberty        |      1 |         20% |                              0.4 |                                  0.500
+	# Equality       |      1 |         20% |                              0.2 |                                  1.000
+    #
+    # (Note that in testing the engine did not seem to handle decimals well beyond the thousandth place.)
+
 	switch_to_order = {
 		picture = switch_to_order
 		potential = {
@@ -84,7 +115,7 @@ political_decisions = {
 			}
 		}
 		
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 0.200 }
 	}
 	
 	switch_to_production = {
@@ -126,7 +157,7 @@ political_decisions = {
 			}
 		}
 		
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 0.250 }
 	}
 	
 	switch_to_autocracy = {
@@ -167,7 +198,7 @@ political_decisions = {
 			}
 		}
 		
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 0.333 }
 	}
 	
 	switch_to_equality = {
@@ -209,7 +240,7 @@ political_decisions = {
 			}
 		}
 		
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 0.500 }
 	}
 	
 	switch_to_liberty = {
@@ -251,6 +282,6 @@ political_decisions = {
 			}
 		}
 		
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 1.000 }
 	}
 }


### PR DESCRIPTION
Before this change the AI only ever picked 'Order' as its national
value. This behaviour is rooted in how the game evaluates which
decisions to activate, proceeding from top to bottom & considering the
`ai_will_do` factor at each step---because that factor was 1, no other
decision were ever considered.

Setting this factor between 0 and 1 for the `switch_to_order` decision
ensures that other national values have a chance to be picked by the AI.
However this factor as well as the subsequent ones have to be computed
carefully. For the sake of future maintenance, the details of that
computation have been included in a comment beside the decisions.

This was favoured over e.g. using a `random_list` command as it was
found that multiple countries activating the decision on the same day
could all end up with the same choice. In practice this affected e.g.
Egypt and some of the Japanese countries, which are Westernised enough
at the start to activate the decision at the same time in the opening
days of the game.

-----

For the purpose of testing this change the following debug decision file
was used:

```
political_decisions = {
    reroll_nv = {
        potential = {}

        allow = {}

        effect = {
            any_country = {
                civilized = no
                nationalvalue = nv_tradition
                set_country_flag = nv_change
                clr_country_flag = switched_nv
                remove_country_modifier = national_confusion
            }
        }

        ai_will_do = { factor = 0 }
    }
}
```

When activated, the `reroll_nv` decision will ensure that all other
countries are eligible to (re)pick a national value the following day.
(Modulo some things like war and revolts.) Looking inside `game.log` for
entries of the kind "Decision: Embrace the Ideal of \<national value\> in
\<country\>" allows for tallying the probabilites of the AI picking each
national value.

-----

Here is an example tally that I obtained:

```
1 January, 1836: Liberty => 1 (25.0%), Equality => 1 (25.0%), Autocracy => 1 (25.0%), Productivity => 1 (25.0%)
2 January, 1836: Autocracy => 1 (33.3%), Order => 1 (33.3%), Liberty => 1 (33.3%)
3 January, 1836: Productivity => 1 (100.0%)
6 January, 1836: Autocracy => 47 (23.2%), Productivity => 42 (20.7%), Order => 40 (19.7%), Equality => 39 (19.2%), Liberty => 35 (17.2%)
11 January, 1836: Productivity => 43 (21.2%), Order => 42 (20.7%), Equality => 41 (20.2%), Autocracy => 39 (19.2%), Liberty => 38 (18.7%)
13 January, 1836: Autocracy => 1 (50.0%), Equality => 1 (50.0%)
21 January, 1836: Equality => 48 (23.4%), Order => 43 (21.0%), Autocracy => 39 (19.0%), Liberty => 38 (18.5%), Productivity => 37 (18.0%)
25 January, 1836: Autocracy => 53 (26.1%), Liberty => 39 (19.2%), Productivity => 39 (19.2%), Equality => 39 (19.2%), Order => 33 (16.3%)

Totals: Autocracy => 22.0%, Equality => 20.5%, Productivity => 19.8%, Order => 19.3%, Liberty => 18.4%
```

For each day it is listed how many countries adopted which NV (with the relative percent amount in brackets). An explanation of the groupings:

- 1 Jan through 3 Jan: the countries which start partially Westernised make their pick
- 6 Jan: 203 countries reroll their NV, the day after activating the debug decision
- 11 Jan: 203 countries reroll their NV
- 13 Jan: Aceh & the Netherlands reroll their NV the day after they peace out
- 21 Jan: 205 countries reroll their NV
- 25 Jan: 203 countries reroll their NV (Tigray had declared war on Aussa in the interim)

The totals are across all those picks & rerolls. They don't reflect the final NV composition.

-----

I'm leaving this PR as a draft because I'm not 100% sure that equiprobable national values are appropriate. Let me know what you think.