### PR TITLE
Add steal_puppet to the peace order

### DIFF
--- a/HPM/common/cb_types.txt
+++ b/HPM/common/cb_types.txt
@@ -81,6 +81,7 @@ oriental_crisis
 unification_release_puppet_cb
 release_puppet
 release_puppet_AI
+steal_puppet
 great_game_cb
 make_puppet
 install_fascism_make_puppet


### PR DESCRIPTION
CB `steal_puppet` was missing from the peace order list, which could
result in unintended results in a peace deal involving multiple CBs.

The CB is placed in-between the CBs that release a vassal and the CBs
that vassalise a country. This seems appropriate as in some sense
`steal_puppet` does those two things in succession.

---

This change has not been tested.