### PR TITLE
Clean up sphere requirements on CBs

### DIFF
--- a/HPM/common/cb_types.txt
+++ b/HPM/common/cb_types.txt
@@ -588,7 +588,6 @@ restore_austrian_empire = {
 			THIS = { NOT = { has_country_flag = accepts_italy } }
 		}
 		NOT = { has_country_modifier = neutrality_modifier }
-		NOT = { in_sphere = THIS }
 		OR = {
 			THIS = {
 				NOT = { has_country_modifier = neutrality_modifier }
@@ -705,7 +704,6 @@ colonial_reconquest_cb = {
 			}
 		}
 		NOT = { number_of_states = 3 }
-		part_of_sphere = no
 		is_vassal = no
 		OR = {
 			THIS = {
@@ -801,7 +799,6 @@ restore_america = {
 				is_core = FSA
 			}
 		}
-		NOT = { in_sphere = THIS }
 		OR = {
 			war_with = THIS
 			THIS = { NOT = { has_country_modifier = punitive_effects } }
@@ -889,7 +886,6 @@ claim_holy_land = {
 				is_core = SYR
 			}
 		}
-		NOT = { in_sphere = THIS }
 		OR = {
 			war_with = THIS
 			THIS = { NOT = { has_country_modifier = punitive_effects } }
@@ -984,7 +980,6 @@ unification_casus_belli = {
 			AND = {
 				war_with = THIS
 				is_culture_group = THIS
-				part_of_sphere = no
 				THIS = { NOT = { tag = AUS } }
 				THIS = { NOT = { tag = KUK } }
 				THIS = { NOT = { tag = DNB } }
@@ -1119,7 +1114,6 @@ unification_annex_casus_belli = {
 			AND = {
 				war_with = THIS
 				is_culture_group = THIS
-				part_of_sphere = no
 				THIS = { NOT = { tag = AUS } }
 				THIS = { NOT = { tag = KUK } }
 				THIS = { NOT = { tag = DNB } }
@@ -1261,7 +1255,7 @@ add_to_sphere = {
 		THIS = { is_greater_power = yes }
 		is_greater_power = no
 		is_vassal = no
-		part_of_sphere = no
+		NOT = { in_sphere = THIS }
 		NOT = { has_country_modifier = neutrality_modifier }
 		OR = {
 			war_with = THIS
@@ -1551,7 +1545,7 @@ unification_add_to_sphere = {
 		NOT = { is_our_vassal = THIS }
 		is_greater_power = no
 		is_vassal = no
-		part_of_sphere = no
+		NOT = { in_sphere = THIS }
 		culture_has_union_tag = yes
 		is_culture_group = THIS
 		cultural_union = { exists = no }
@@ -3268,7 +3262,6 @@ great_game_cb = {
 			has_global_flag = british_dismantled
 			is_our_vassal = THIS
 			truce_with = THIS
-			in_sphere = THIS
 		}
 		OR = {
 			neighbour = THIS
@@ -8555,7 +8548,6 @@ colonial_conquest = {
 		}
 		number_of_states = 2
 		NOT = { has_country_modifier = neutrality_modifier }
-		NOT = { in_sphere = THIS }
 		is_vassal = no
 		civilized = no
 		exists = yes
@@ -9021,7 +9013,6 @@ colonial_conquest_full = {
 		NOT = { number_of_states = 2 }
 		NOT = { is_our_vassal = THIS }
 		NOT = { has_country_modifier = neutrality_modifier }
-		NOT = { in_sphere = THIS }
 		is_vassal = no
 		civilized = no
 		exists = yes
@@ -9424,7 +9415,6 @@ claim_colonial_region = {
 		is_vassal = no
 		capital_scope = { continent = africa }
 		ai = yes
-		NOT = { in_sphere = THIS }
 		neighbour = THIS
 		
 		OR = {
@@ -10098,7 +10088,6 @@ claim_colonial_region_full = {
 		is_vassal = no
 		capital_scope = { continent = africa }
 		ai = yes
-		NOT = { in_sphere = THIS }
 		neighbour = THIS
 		
 		OR = {
@@ -10589,7 +10578,6 @@ steal_puppet = {
 	
 	# can_use = {
 		# NOT = { is_our_vassal = THIS }
-		# NOT = { in_sphere = THIS }
 		# OR = {
 			# war_with = THIS
 			# THIS = {

--- a/HPM/common/cb_types.txt
+++ b/HPM/common/cb_types.txt
@@ -81,6 +81,7 @@ oriental_crisis
 unification_release_puppet_cb
 release_puppet
 release_puppet_AI
+steal_puppet
 great_game_cb
 make_puppet
 install_fascism_make_puppet


### PR DESCRIPTION
Various CBs had one of the two following sphere requirements:

- `part_of_sphere = no`
- `NOT = { in_sphere = THIS }`

As discussed in #47 the former is a legacy requirement. As to the latter
it is of little effect: the game already prevents fabrication or
declaration against one's own spherelings.

What practical effect these requirements did have (if any) was to
invalidate CBs handed out by event/decision, or that were active in
ongoing wars. (Though the latter has proved difficult to replicate
in-game.)

This change removes most (see next paragraph) such requirements to spare
frustration and confusion from the player. As a side-effect this
introduces some overlap in functionality between `add_to_sphere` and
`take_from_sphere`.

The purely sphere-making CBs (`add_to_sphere` and
`unification_add_to_sphere`) are changed to not work on one's own
sphereling specifically. Without this requirement a country could be
sitting on an `add_to_sphere` CB (when gained from an event/decision)
that would be displayed e.g. on the diplomacy screen but that they could
not use--unless they removed the country from their sphere, upon which
they could declare... to re-add the country to it.

---

This PR sits on top of #60. The change has not been tested.