### PR TITLE
Change 'Alternative' Treaty of London / allow annexing Zeeland

### DIFF
--- a/HPM/events/BELFlavor.txt
+++ b/HPM/events/BELFlavor.txt
@@ -310,7 +310,7 @@ country_event = {
 		prestige = -20
 		relation = { who = ENG value = 50 }
 		relation = { who = NET value = 150 }
-		381 = { remove_core = BEL }
+		NET_379 = { remove_core = BEL }
 		397 = { remove_core = BEL }
 		random_owned = {
 			limit = { LUX = { exists = no } }
@@ -542,7 +542,11 @@ country_event = {
 			end_war = NET
 		}
 		relation = { who = NET value = 150 }
+		378 = { remove_core = BEL }
+		379 = { remove_core = BEL }
+		380 = { remove_core = BEL }
 		381 = { remove_core = NET }
+		397 = { remove_core = NET }
 		BEL_394 = { remove_core = NET }
 		BEL_387 = { remove_core = NET }
 		NET = {
@@ -595,7 +599,8 @@ country_event = {
 			end_war = NET
 		}
 		relation = { who = NET value = -100 }
-		381 = { remove_core = NET }
+		397 = { remove_core = NET }
+		NET_379 = { remove_core = NET }
 		BEL_394 = { remove_core = NET }
 		BEL_387 = { remove_core = NET }
 		NET = {
@@ -606,36 +611,36 @@ country_event = {
 				secede_province = BEL
 			}
 		}
-		NET = {
-			random_owned = {
-				limit = {
-					OR = {
-						is_overseas = yes
-						is_colonial = yes
-					}
-					NOT = { is_core = NET }
-					port = yes
-				}
-				state_scope = {
-					any_owned = { secede_province = BEL }
-				}
-			}
-		}
-		NET = {
-			random_owned = {
-				limit = {
-					OR = {
-						is_overseas = yes
-						is_colonial = yes
-					}
-					NOT = { is_core = NET }
-					port = yes
-				}
-				state_scope = {
-					any_owned = { secede_province = BEL }
-				}
-			}
-		}
+		#NET = {
+		#	random_owned = {
+		#		limit = {
+		#			OR = {
+		#				is_overseas = yes
+		#				is_colonial = yes
+		#			}
+		#			NOT = { is_core = NET }
+		#			port = yes
+		#		}
+		#		state_scope = {
+		#			any_owned = { secede_province = BEL }
+		#		}
+		#	}
+		#}
+		#NET = {
+		#	random_owned = {
+		#		limit = {
+		#			OR = {
+		#				is_overseas = yes
+		#				is_colonial = yes
+		#			}
+		#			NOT = { is_core = NET }
+		#			port = yes
+		#		}
+		#		state_scope = {
+		#			any_owned = { secede_province = BEL }
+		#		}
+		#	}
+		#}
 		relation = { who = ENG value = -50 }
 		relation = { who = FRA value = -50 }
 		add_country_modifier = {

--- a/HPM/history/provinces/low countries/378 - Middelburg.txt
+++ b/HPM/history/provinces/low countries/378 - Middelburg.txt
@@ -1,5 +1,7 @@
 owner = NET
 controller = NET
 add_core = NET
+add_core = BEL
 trade_goods = fish
 life_rating = 35
+1861.1.1 = { remove_core = BEL }

--- a/HPM/history/provinces/low countries/379 - Eindhoven.txt
+++ b/HPM/history/provinces/low countries/379 - Eindhoven.txt
@@ -1,6 +1,8 @@
 owner = NET
 controller = NET
 add_core = NET
+add_core = BEL
 trade_goods = coal
 life_rating = 35
 terrain = mining_district
+1861.1.1 = { remove_core = BEL }

--- a/HPM/history/provinces/low countries/380 - Breda.txt
+++ b/HPM/history/provinces/low countries/380 - Breda.txt
@@ -1,6 +1,8 @@
 owner = NET
 controller = NET
 add_core = NET
+add_core = BEL
 trade_goods = cattle
 life_rating = 35
 1861.1.1 = { railroad = 1 }
+1861.1.1 = { remove_core = BEL }


### PR DESCRIPTION
Belgium now starts with cores on all provinces in the Zeeland state. The 'Let us demand concessions' option of the new alternate Treaty of London (after a Dutch surrender) now allows taking the Zeeland state instead of 2 random colonies, resulting in a Belgium / Netherlands split based on religion (catholic Belgium and protestant Netherlands).

In my opinion this would be a more likely result of Belgium and its allies occupying the Netherlands instead of gaining some colonies. The added cores now allow the Belgian player to break the ceasefire instead of hoping for the Dutch AI to do so.

This is of course a significant change in the starting position for the low countries, so feel free to refuse if this does not fit with your vision of the mod.

For testing: as Belgium trigger events 36710 and 36716