### PR TITLE
Work on Austrian cores

### DIFF
--- a/HPM/decisions/AUS.txt
+++ b/HPM/decisions/AUS.txt
@@ -42,11 +42,16 @@ political_decisions = {
 				}
 				remove_core = KRA
 			}
-			AUS_771 = { remove_core = HUN }
+			#AUS_771 = { remove_core = HUN }
+			624 = { remove_core = HUN }
+			778 = { remove_core = HUN }
 			HUN = {
 				all_core = { add_core = KUK }
 			}
 			CRO = {
+				all_core = { add_core = KUK }
+			}
+			GLM = {
 				all_core = { add_core = KUK }
 			}
 			any_pop = {
@@ -77,10 +82,10 @@ political_decisions = {
 						tag = NGF
 						tag = PRU
 						tag = GER
-						}
+					}
 					exists = yes
 					is_greater_power = yes
-					}
+				}
 				relation = { who = THIS value = 50 }
 			}
 		}
@@ -162,7 +167,10 @@ political_decisions = {
 
 		effect = {
 			HUN = {
-				all_core = { remove_core = KUK }
+				all_core = {
+					limit = { NOT = { province_id = 624 } }
+					remove_core = KUK
+				}
 			}
 			POL = {
 				all_core = { remove_core = KUK }
@@ -171,6 +179,8 @@ political_decisions = {
 				remove_core = KUK
 				add_core = AUS
 			}
+			AUS_780 = { remove_core = AUS }
+			2582 = { remove_core = AUS }
 			any_pop = {
 				limit = { has_pop_culture = hungarian }
 				militancy = 4

--- a/HPM/decisions/Germany.txt
+++ b/HPM/decisions/Germany.txt
@@ -865,7 +865,6 @@ political_decisions = {
 			diplomatic_influence = { who = SGM value = -400 }
 			release = SGM
 			leave_alliance = SGM
-			SGM = { neutrality = yes }
 			594 = {
 				remove_core = SGM
 				add_core = THIS

--- a/HPM/decisions/Political.txt
+++ b/HPM/decisions/Political.txt
@@ -909,6 +909,7 @@ political_decisions = {
 				AND = { tag = VEN owns = 729 NOT = { capital = 729 } }
 				AND = { tag = KOR owns = 1624 NOT = { capital = 1624 } }
 				AND = { tag = ALB owns = 849 NOT = { capital = 849 } }
+				AND = { tag = SLO owns = 849 NOT = { capital = 768 } }
 				AND = { tag = ASH civilized = yes owns = 1907 NOT = { capital = 1907 } }
 			}
 		}
@@ -916,6 +917,7 @@ political_decisions = {
 		allow = { war = no }
 		
 		effect = {
+			random_owned = { limit = { owner = { tag = SLO } } owner = { capital = 768 } }
 			random_owned = { limit = { owner = { tag = ALB } } owner = { capital = 849 } }
 			random_owned = { limit = { owner = { tag = KOR } } owner = { capital = 1624 } }
 			random_owned = { limit = { owner = { tag = ASH } } owner = { capital = 1907 } }

--- a/HPM/events/Greater Germany.txt
+++ b/HPM/events/Greater Germany.txt
@@ -780,19 +780,25 @@ country_event = {
 		random_country = {
 			limit = {
 				OR = {
-				tag = KUK
-				tag = FROM
+					tag = KUK
+					tag = FROM
 				}
 			}
 			all_core = {
-				limit = { is_core = HUN }
+				limit = {
+					is_core = HUN
+					NOT = { province_id = 623 }
+				}
 				remove_core = KUK
 			}
 		}
 		FROM = {
 			all_core = {
 				limit = {
-					NOT = { is_core = HUN }
+					OR = {
+						NOT = { is_core = HUN }
+						region = AUS_623
+					}
 				}
 				add_core = GER
 			}
@@ -852,14 +858,10 @@ country_event = {
 	option = {
 		name = "EVT31516OPTB"
 		badboy = 20
-		FROM = {
-			all_core = {
-				limit = {
-					NOT = { is_core = HUN }
-				}
-				add_core = GER
-			}
-		}
+		AUS_612 = { add_core = GER remove_core = HUN }
+		AUS_734 = { add_core = GER remove_core = HUN }
+		AUS_613 = { add_core = GER remove_core = HUN }
+		AUS_619 = { add_core = GER remove_core = HUN }
 		any_country = {
 			limit = {
 				is_greater_power = yes
@@ -1021,18 +1023,10 @@ country_event = {
 		badboy = 20
 		diplomatic_influence = { who = FROM value = -400 }
 		relation = { who = FROM value = -400 }
-		FROM = {
-			all_core = {
-				limit = {
-					OR = {
-						culture = south_german
-						culture = north_german
-					}
-					NOT = { is_core = HUN }
-				}
-				add_core = GER
-			}
-		}
+		AUS_612 = { add_core = GER remove_core = HUN }
+		AUS_734 = { add_core = GER remove_core = HUN }
+		AUS_613 = { add_core = GER remove_core = HUN }
+		AUS_619 = { add_core = GER remove_core = HUN }
 		add_casus_belli = {
 			target = FROM
 			type = humiliate
@@ -1141,14 +1135,10 @@ country_event = {
 		name = "EVT31519OPTA"
 		prestige = 10
 		badboy = 20
-		FROM = {
-			all_core = {
-				limit = {
-					NOT = { is_core = HUN }
-				}
-				add_core = GER
-			}
-		}
+		AUS_612 = { add_core = GER remove_core = HUN }
+		AUS_734 = { add_core = GER remove_core = HUN }
+		AUS_613 = { add_core = GER remove_core = HUN }
+		AUS_619 = { add_core = GER remove_core = HUN }
 		FROM = { country_event = 31520 }
 		any_country = {
 			limit = {
@@ -1258,9 +1248,42 @@ country_event = {
 				all_core = { remove_core = KUK }
 			}
 		}
+		
+		any_country = {
+			limit = {
+				tag = HUN
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31517
+		}
+		any_country = {
+			limit = {
+				OR = {
+					tag = CRO
+					tag = SLO
+					tag = SLV
+					tag = BOH
+				}
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31517
+		}
 		any_country = {
 			limit = {
 				NOT = { is_culture_group = germanic }
+				NOT = { is_culture_group = italian }
 				NOT = { tag = HUN }
 				any_core = {
 					owned_by = THIS
@@ -1274,7 +1297,8 @@ country_event = {
 		}
 		any_country = {
 			limit = {
-				tag = HUN
+				is_culture_group = italian
+				NOT = { tag = HUN }
 				any_core = {
 					owned_by = THIS
 					NOT = { is_core = GER }
@@ -1359,6 +1383,69 @@ country_event = {
 			}
 			country_event = 31522
 		}
+		
+		
+		any_country = {
+			limit = {
+				tag = HUN
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31526
+		}
+		any_country = {
+			limit = {
+				OR = {
+					tag = CRO
+					tag = SLO
+					tag = SLV
+					tag = BOH
+				}
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31526
+		}
+		any_country = {
+			limit = {
+				NOT = { is_culture_group = germanic }
+				NOT = { is_culture_group = italian }
+				NOT = { tag = HUN }
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31526
+		}
+		any_country = {
+			limit = {
+				is_culture_group = italian
+				NOT = { tag = HUN }
+				any_core = {
+					owned_by = THIS
+					NOT = { is_core = GER }
+					is_colonial = no
+				}
+				exists = no
+				is_cultural_union = no
+			}
+			country_event = 31526
+		}
+		
 		any_country = {
 			limit = {
 				any_core = { owned_by = THIS }

--- a/HPM/events/PRUFlavor.txt
+++ b/HPM/events/PRUFlavor.txt
@@ -832,10 +832,7 @@ country_event = {
 		608 = { remove_core = GER }
 		608 = { remove_core = PRU }
 		608 = { remove_core = NEH }
-		NEH = {
-			neutrality = yes
-			annex_to = SWI
-		}
+		SWI = { inherit = NEH }
 		
 		relation = { who = SWI value = 75 }
 		diplomatic_influence = { who = SWI value = 50 }

--- a/HPM/history/pops/1836.1.1/Poland.txt
+++ b/HPM/history/pops/1836.1.1/Poland.txt
@@ -810,7 +810,7 @@
 	farmers = {
 		culture = polish
 		religion = catholic
-		size = 45715 
+		size = 48715 
 	}
 	
 	serfs = {


### PR DESCRIPTION
* Reworked the "Greater Germany" event chain so it adds cores (for Germany) to Austria proper only. This is done to fix weirdness in regards to core distribution, but at some point I'd like to rework the whole chain and Austria's starting cores to be more consistent.
* Fixed country release distribution if Austria is absorbed, to ensure more majors are released instead of a bunch of minors. Also fixed the cores that A-H gets, the ones that Hungary loses and the ones Austria gains when it flips from A-H back to Austria so it's all consistent across the board. Previously Austria would gain cores when flipping from A-H.