### PR TITLE
Welsh liberal party minor fix

### DIFF
--- a/HPM/common/countries/Wales.txt
+++ b/HPM/common/countries/Wales.txt
@@ -4,7 +4,7 @@ graphical_culture = EuropeanGC
 party = {
 	name = "WHA_liberal"
 	start_date = 1830.1.1
-	end_date = 1859.1.1
+	end_date = 2000.1.1
 
 	ideology = liberal
 


### PR DESCRIPTION
Changed the Welsh liberal party's end date as Wales has only one liberal party.