### PR TITLE
Reactionary revolts and theocracies

### DIFF
--- a/HPM/common/rebel_types.txt
+++ b/HPM/common/rebel_types.txt
@@ -28,7 +28,7 @@ reactionary_rebels = {
 		prussian_constitutionalism = absolute_monarchy
 		hms_government = absolute_monarchy
 		democracy = presidential_dictatorship
-		theocracy = absolute_monarchy
+		theocracy = theocracy
 	}
 	
 	
@@ -3904,7 +3904,7 @@ unciv_reactionary_rebels = {
 		prussian_constitutionalism = absolute_monarchy
 		hms_government = absolute_monarchy
 		democracy = absolute_monarchy
-		theocracy = absolute_monarchy
+		theocracy = theocracy
 	}
 	
 	defection = none					# Will defect to the "best" alternative.


### PR DESCRIPTION
If a country is a theocracy and reactionaries revolt and win then the government doesn't change anymore to absolute monarchy. I'm no sure why this wasn't already the case. Reactionaries want to preserve the way things were and if the government of their country was an established theocracy then they would want to keep it that way. I suppose perhaps the only exceptions could be countries that over the course of the game change from absolute monarchy to theocracy, specifically the Heavenly Kingdom and Mongolia.