### PR TITLE
National focus mapmode fix

### DIFF
--- a/HPM/interface/mapitems.gfx
+++ b/HPM/interface/mapitems.gfx
@@ -129,7 +129,7 @@ objectTypes = {
 		name = "national_focus"
 		textureFile = "gfx\\interface\\province_natfocus_strip.dds"
 		scale = 1.5
-		noOfFrames = 32
+		noOfFrames = 38
 	}	
 		
 	billboardType = {


### PR DESCRIPTION
The national focus icons on the national focus mapmode were all misaligned. This fixes it.