### PR TITLE
Congo production fix

### DIFF
--- a/HPM/events/Congo.txt
+++ b/HPM/events/Congo.txt
@@ -308,7 +308,7 @@ country_event = {
 			any_pop = { militancy = 3 }
 		}
 		any_owned = { limit = { is_core = CNG } add_province_modifier = { name = the_massacre duration = 2190 } }
-		country_event = { id = 199048 days = 2 }
+		country_event = { id = 199049 days = 2 }
 		set_global_flag = congo_free_state_over
 		set_country_flag = lied_about_congo
 		set_country_flag = not_congo_primary_culture
@@ -377,6 +377,7 @@ country_event = {
 			all_core = { remove_core = LBA }
 			all_core = { remove_core = LUN }
 			all_core = { remove_core = MNG }
+			country_event = { id = 199049 days = 2 }
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		clr_country_flag = historical_congo
@@ -406,7 +407,7 @@ country_event = {
 			all_core = { remove_core = LBA }
 			all_core = { remove_core = LUN }
 			all_core = { remove_core = MNG }
-			country_event = { id = 199048 days = 2 }
+			country_event = { id = 199049 days = 2 }
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		clr_country_flag = historical_congo
@@ -657,7 +658,7 @@ country_event = {
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		inherit = CNG
-		country_event = { id = 199048 days = 2 }
+		country_event = { id = 199049 days = 2 }
 		ai_chance = {
 			factor = 0.5
 			modifier = { factor = 0 badboy = 0.5 }
@@ -695,7 +696,7 @@ country_event = {
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		inherit = CNG
-		country_event = { id = 199048 days = 2 }
+		country_event = { id = 199049 days = 2 }
 		ai_chance = {
 			factor = 0.5
 			modifier = { factor = 100 badboy = 0.5 }
@@ -752,7 +753,7 @@ country_event = {
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		inherit = CNG
-		country_event = { id = 199048 days = 2 }
+		country_event = { id = 199049 days = 2 }
 	}
 }
 
@@ -846,7 +847,7 @@ country_event = {
 		}
 		random_country = { limit = { tag = KON ai = yes } all_core = { remove_core = KON } }
 		inherit = CNG
-		country_event = { id = 199048 days = 2 }
+		country_event = { id = 199049 days = 2 }
 		ai_chance = { factor = 0.9 }
 	}
 	


### PR DESCRIPTION
The events about the Congo Free state triggered the wrong colonial production event. This fixes it and now the events correctly trigger the colonial production event for the Congo (Zaire).

I also added the colonial production event to trigger if the player takes the third option of the Congo Destiny event since it was missing.