### PR TITLE
Exclude uncivs from regencies

### DIFF
--- a/HPM/events/GovernmentFlavor.txt
+++ b/HPM/events/GovernmentFlavor.txt
@@ -6,6 +6,7 @@ country_event = {
     picture = "regency"
 
     trigger = {
+        civilized = yes
         OR = {
             government = absolute_monarchy
             government = prussian_constitutionalism
@@ -30,17 +31,14 @@ country_event = {
         }
         modifier = {
             factor = 0.75
-            civilized = yes
             capital_scope = { average_militancy = 9 }
         }
         modifier = {
             factor = 0.75
-            civilized = yes
             capital_scope = { average_militancy = 8 }
         }
         modifier = {
             factor = 0.9
-            civilized = yes
             capital_scope = { average_militancy = 7 }
         }
     }


### PR DESCRIPTION
A large part of unciv gameplay is navigating your country's militancy
and consciousness. However with few options available to the player to
mitigate rises in discontentment, this more or less ends up as a race
for the country to achieve Westernisation before reactionary revolts are
no longer manageable.

In practical term this means that the regency event is a death sentence
to an unciv, unless the country was already close to 100%
Westernisation. This change limits the event to civilised countries
only.

---

Alternatives to this PR may instead involve:

- adding a different regency modifier for uncivs, with appropriate effects (research points? consciousness but not militancy? ideology?)
- giving an effect to unciv regencies that involves no modifier at all
- giving unciv countries new ways of managing militancy/consciousness in general

This change has not been tested. 