### PR TITLE
Ensure steal_puppet affects all valid targets

### DIFF
--- a/HPM/common/cb_types.txt
+++ b/HPM/common/cb_types.txt
@@ -10582,6 +10582,7 @@ steal_puppet = {
                         any_owned_province = { port = yes }
                     }
                     neighbour = THIS
+                    war_with = THIS
                     any_neighbor_country = {
                         OR = {
                             vassal_of = THIS


### PR DESCRIPTION
This fixes an inconsistency between `allowed_countries` and the concrete
marking of targets performed in `on_add`. This should make sure that
targets added during a war don't end up independent.

---

I did not test this change.