### PR TITLE
Remove correct Basotho cores in Mfecane Matabele

### DIFF
--- a/HPM/events/African Uncivs.txt
+++ b/HPM/events/African Uncivs.txt
@@ -90,7 +90,7 @@ country_event = { #The Mfecane
     option = {
         name = "EVT95519OPTA"
         set_country_flag = the_mfecane
-        any_owned = { limit = { is_core = THIS } remove_core = GAZ remove_core = ZUL remove_core = BAS }
+        any_owned = { limit = { is_core = THIS } remove_core = GAZ remove_core = ZUL remove_core = BSH }
         any_pop = { militancy = -9 consciousness = -9 }
         2105 = { life_rating = 20 }
         2106 = { life_rating = 15 }


### PR DESCRIPTION
Without this change nonexistent `BAS` aka Bastar cores were being
mistakenly removed.

---

Crediting [HFM/#171] for the helpful bug report. I did not test this change.

[HFM/#171]: https://github.com/SighPie/HFM/issues/171