### PR TITLE
Swedish and danish navies

### DIFF
--- a/HPM/history/units/DEN_oob.txt
+++ b/HPM/history/units/DEN_oob.txt
@@ -65,12 +65,67 @@ navy = {
     name = "Royal Navy"
     location = 372
     ship = {
-        name= "Danmark"
+        name= "Dronning Marie"
         type = manowar
     }
 
     ship = {
-        name= "Dronning Marie"
+        name= "Valdemar"
         type = manowar
+    }
+	
+	ship = {
+        name= "Frederik den Sjette"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Skjold"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Danmark"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Phøenix"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Freja"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Rota"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Havfruen"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Bellona"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Nymphen"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Dronning Marie"
+        type = Fylla
+    }
+	
+	ship = {
+        name= "Dronning Marie"
+        type = Minerva
     }
 }

--- a/HPM/history/units/DEN_oob.txt
+++ b/HPM/history/units/DEN_oob.txt
@@ -90,7 +90,7 @@ navy = {
     }
 	
 	ship = {
-        name= "Phøenix"
+        name= "Phoenix"
         type = manowar
     }
 	
@@ -120,12 +120,12 @@ navy = {
     }
 	
 	ship = {
-        name= "Dronning Marie"
-        type = Fylla
+        name= "Fylla"
+        type = frigate
     }
 	
 	ship = {
-        name= "Dronning Marie"
-        type = Minerva
+        name= "Minerva"
+        type = frigate
     }
 }

--- a/HPM/history/units/SWE_oob.txt
+++ b/HPM/history/units/SWE_oob.txt
@@ -157,8 +157,32 @@ navy = {
         name= "Manligheten"
         type = manowar
     }
-
-
+	
+	ship = {
+        name= "Dristigheten"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Försiktigheten"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Wasa"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Prins Oscar"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Gustav den Store"
+        type = manowar
+    }
+	
     ship = {
         name= "Camilla"
         type = frigate
@@ -178,20 +202,30 @@ navy = {
         name= "Galatea"
         type = frigate
     }
+	
+	ship = {
+        name= "Josefine"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Göteborg"
+        type = frigate
+    }
 
 
     ship = {
-        name= "1st Transport Flotilla"
+        name= "Gäddan"
         type = clipper_transport
     }
 
     ship = {
-        name= "2nd Transport Flotilla"
+        name= "Två Bröder"
         type = clipper_transport
     }
 
     ship = {
-        name= "3rd Transport Flotilla"
+        name= "Harmonien"
         type = clipper_transport
     }
 


### PR DESCRIPTION
Fixed the navies of Sweden and Denmark. 

Sweden

- 9 Man'o'wars
- 6 Frigates
- 3 Transports


Denmark

- 6 Man'o'wars
- 7 Frigates

Sweden now goes over the supply throughput limit so they need at least one more level one port.

https://www.academia.edu/35251769/THE_NAVIES_OF_THE_WORLD_1835_1840
http://felipe.mbnet.fi/index.html