### PR TITLE
Ottoman and Egyptian navies

### DIFF
--- a/HPM/history/units/EGY_oob.txt
+++ b/HPM/history/units/EGY_oob.txt
@@ -30,83 +30,83 @@ navy = {
     name = "Taba"
     location = 1751
     ship = {
-        name= "Toushka"
+        name= "Aboukir"
         type = manowar
     }
 
     ship = {
-        name= "Sharm El-Sheikh"
+        name= "Beylan"
         type = manowar
     }
 
     ship = {
-        name= "Damyat"
+        name= "Mansourah"
         type = manowar
     }
 
     ship = {
-        name= "Rasheed"
+        name= "Mahalet-el- Koubra"
         type = manowar
     }
 
     ship = {
-        name= "El Suez"
+        name= "Iskander"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Homs"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Masr"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Aké"
         type = manowar
     }
 
     ship = {
-        name= "El Aboukir"
+        name= "Menoufieh"
         type = frigate
     }
 
     ship = {
-        name= "Najim al Zafir"
+        name= "Mouftagehad"
         type = frigate
     }
 
     ship = {
-        name= "Cairo"
+        name= "Kafrecheick"
         type = frigate
     }
 
     ship = {
-        name= "Al Iskandariyah"
+        name= "Damietta"
         type = frigate
     }
 
     ship = {
-        name= "Aswan"
+        name= "Raschid"
         type = frigate
     }
 
     ship = {
-        name= "Port Said"
+        name= "Bahireh"
         type = frigate
     }
 
     ship = {
-        name= "Marsa Matruh"
+        name= "Sir-I Gihad"
         type = frigate
     }
 
     ship = {
-        name= "Bur Tawfiq"
-        type = frigate
-    }
-
-    ship = {
-        name= "Al Ghardaqah"
-        type = frigate
-    }
-
-    ship = {
-        name= "Bur Safajah"
-        type = frigate
-    }
-
-    ship = {
-        name= "1st transport flotilla"
-        type = clipper_transport
+        name= "Nile"
+        type = steam_transport
     }
 
 }

--- a/HPM/history/units/TUR_oob.txt
+++ b/HPM/history/units/TUR_oob.txt
@@ -428,128 +428,153 @@ navy = {
     name = "Ottoman Navy"
     location = 860
     ship = {
-        name= "Masudiya"
+        name= "Selimiye"
         type = manowar
     }
 
     ship = {
-        name= "Sadd al Bahri"
+        name= "Mahmudiye"
         type = manowar
     }
 
     ship = {
-        name= "Ankay i Barhi"
+        name= "Mesudiye"
         type = manowar
     }
 
     ship = {
-        name= "Taus i Barhi"
+        name= "Fethiye"
         type = manowar
     }
 
     ship = {
-        name= "Tevfik Nyuma"
+        name= "Memduhiye"
         type = manowar
     }
 
     ship = {
-        name= "Bisharet Nyuma"
+        name= "Tesrifiye"
         type = manowar
     }
 
     ship = {
-        name= "Killid i Barhi"
+        name= "Mukaddeme i Hayir"
         type = manowar
     }
 
     ship = {
-        name= "Heybetendaz"
+        name= "Rehber i Nusret"
         type = manowar
     }
 
     ship = {
-        name= "Melek i Barhi"
+        name= "Burc i Zafer"
         type = manowar
     }
 
     ship = {
-        name= "Sayyad i Barhi"
+        name= "Fevziye"
         type = manowar
     }
 
     ship = {
-        name= "Gulbang i Nusret"
+        name= "Tevfikiye"
         type = manowar
     }
 
     ship = {
-        name= "Jebel Andaz"
+        name= "Peyk i Mesiret"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Necm i Sevket"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Feyz i Memduh"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Mukaddime i Seref"
         type = manowar
     }
 
     ship = {
-        name= "Iskenderiya"
+        name= "Nusretiye"
         type = frigate
     }
 
     ship = {
-        name= "Badere i Zaffar"
+        name= "Hifz ur Rahman"
         type = frigate
     }
 
     ship = {
-        name= "Mahubey Subham"
+        name= "Kaaid i Zafer"
         type = frigate
     }
 
     ship = {
-        name= "Metelin"
+        name= "Nesim i Zafer"
         type = frigate
     }
 
     ship = {
-        name= "Denyuvet"
+        name= "Serefresan"
         type = frigate
     }
 
     ship = {
-        name= "Rahbar i Alam"
+        name= "AvniIlah"
         type = frigate
     }
 
     ship = {
-        name= "Malbaik Nesuret"
+        name= "Yaveri Tevfik"
         type = frigate
     }
 
     ship = {
-        name= "Bedr i Zafar"
+        name= "Fazlullah"
         type = frigate
     }
 
     ship = {
-        name= "Meskeni Ghazi"
+        name= "Mazhar i Tevfik"
         type = frigate
     }
 
     ship = {
-        name= "Fakim i Zafar"
+        name= "Pertev Fesan"
         type = frigate
     }
 
     ship = {
-        name= "1st Transport Flotilla"
-        type = clipper_transport
+        name= "Sadiye"
+        type = frigate
     }
 
     ship = {
-        name= "2nd Transport Flotilla"
-        type = clipper_transport
+        name= "Tair i Bahri"
+        type = frigate
     }
 
     ship = {
-        name= "3rd Transport Flotilla"
-        type = clipper_transport
+        name= "Suriye"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Sihab i Bahri"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Mirat i Zafer"
+        type = frigate
     }
 
 }


### PR DESCRIPTION
Fixed the navies of the Ottoman Empire and Egypt.

Ottomans

- 15 Man'o'wars
- 15 Frigates

Egypt
- 8 Man'o'wars
- 7 Frigates
 - 1 Troopship

https://www.academia.edu/35251769/THE_NAVIES_OF_THE_WORLD_1835_1840
http://felipe.mbnet.fi/index.html
