### PR TITLE
Sardinian and Omani navies

### DIFF
--- a/HPM/history/units/OMA_oob.txt
+++ b/HPM/history/units/OMA_oob.txt
@@ -38,6 +38,36 @@ army = {
 navy = {
     name = "Omani Fleet"
     location = 1166
+	ship = {
+        name = "Liverpool"
+        type = manowar
+    }
+	
+	ship = {
+        name = "Shah Alam"
+        type = frigate
+    }
+	
+	ship = {
+        name = "Caroline"
+        type = frigate
+    }
+	
+	ship = {
+        name = "Humayun Shah"
+        type = frigate
+    }
+	
+	ship = {
+        name = "Prince of Wales"
+        type = frigate
+    }
+	
+	ship = {
+        name = "Piedmontaise"
+        type = frigate
+    }
+	
     ship = {
         name= "Transport Flotilla"
         type = clipper_transport

--- a/HPM/history/units/SAR_oob.txt
+++ b/HPM/history/units/SAR_oob.txt
@@ -159,7 +159,7 @@ navy = {
     }
 
     ship = {
-        name= "Haute Combe"
+        name= "Des Geneys"
         type = frigate
     }
 
@@ -170,6 +170,26 @@ navy = {
 
     ship = {
         name= "Regina"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Euridice"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Commercio di Genova"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Maria Teresa"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Maria Cristina"
         type = frigate
     }
 


### PR DESCRIPTION
Fixed the navies of Sardinia and Oman.

Sardinia

- 8 Frigates
- 3 Transports

Austria

- 1 Man'o'war
- 5 Frigates
- 2 Transports

https://www.academia.edu/35251769/THE_NAVIES_OF_THE_WORLD_1835_1840
http://felipe.mbnet.fi/index.html