### PR TITLE
Fix Dutch Belgian Truce

### DIFF
--- a/HPM/history/units/NET_oob.txt
+++ b/HPM/history/units/NET_oob.txt
@@ -1,4 +1,4 @@
-NET = {
+BEL = {
     truce_until = 1839.4.1
 }
 ENG = {


### PR DESCRIPTION
Fixes a typo in the NET_oob file so that the starting truce between Belgium and the Netherlands is no longer one-sided.