### PR TITLE
US, Spanish and Portuguese navies

### DIFF
--- a/HPM/history/units/POR_oob.txt
+++ b/HPM/history/units/POR_oob.txt
@@ -148,53 +148,33 @@ navy = {
     name = "Portuguese Royal Navy"
     location = 521
     ship = {
-        name= "Rainha de Portugal"
-        type = manowar
-    }
-
-    ship = {
         name= "Dom João VI"
         type = manowar
     }
 
     ship = {
-        name= "Nossa Senhora da Conceição"
+        name= "São Vicente"
         type = manowar
     }
-
-    ship = {
-        name= "São Sebastião"
-        type = manowar
+	
+	ship = {
+        name= "Duquesa de Braganza"
+        type = frigate
     }
-
-    ship = {
-        name= "Amazônia"
-        type = manowar
+	
+	ship = {
+        name= "Dom Pedro"
+        type = frigate
     }
-
-    ship = {
-        name= "Princesa Carlota"
-        type = manowar
+	
+	ship = {
+        name= "Rainha de Portugal"
+        type = frigate
     }
-
-    ship = {
-        name= "Teresa"
-        type = manowar
-    }
-
-    ship = {
-        name= "Príncipe do Brasil"
-        type = manowar
-    }
-
-    ship = {
-        name= "Algarves"
-        type = manowar
-    }
-
-    ship = {
-        name= "Maria II"
-        type = manowar
+	
+	ship = {
+        name= "Dona Maria II"
+        type = frigate
     }
 
     ship = {

--- a/HPM/history/units/SPA_oob.txt
+++ b/HPM/history/units/SPA_oob.txt
@@ -334,33 +334,63 @@ army = {
 }
 
 navy = {
+    name = "Armada Real Española"
+    location = 506
+    ship = {
+        name= "Héroe"
+        type = manowar
+    }
+
+    ship = {
+        name= "Soberano"
+        type = manowar
+    }
+	
+	ship = {
+        name= "Guerrero"
+        type = manowar
+    }
+
+    ship = {
+        name= "Restauración"
+        type = frigate
+    }
+
+    ship = {
+        name= "Esperanza"
+        type = frigate
+    }
+
+    ship = {
+        name= "Perla"
+        type = frigate
+    }
+	
+	ship = {
+        name= "Isabel II"
+        type = steam_transport
+    }
+
+    ship = {
+        name= "1a Flotilla de Transporte"
+        type = clipper_transport
+    }
+
+    ship = {
+        name= "2a Flotilla de Transporte"
+        type = clipper_transport
+    }
+
+    ship = {
+        name= "3a Flotilla de Transporte"
+        type = clipper_transport
+    }
+}
+
+navy = {
     name = "Armada de Cuba"
     location = 2212
 
-    ship = {
-        name = "Santiago"
-        type = manowar
-    }
-
-    ship = {
-        name = "Hespérides"
-        type = manowar
-    }
-
-    ship = {
-        name = "Centinela"
-        type = manowar
-    }
-
-    ship = {
-        name = "Isla de Cuba"
-        type = frigate
-    }
-
-    ship = {
-        name = "Cristóbal Colón"
-        type = frigate
-    }
 
     ship = {
         name= "1a Flotilla de Transporte"
@@ -382,89 +412,6 @@ navy = {
     name = "Armada de Filipinas"
     location = 1455
 
-    ship = {
-        name = "Alerta"
-        type = manowar
-    }
-
-    ship = {
-        name = "San Fernando"
-        type = manowar
-    }
-
-    ship = {
-        name = "Legazpi"
-        type = manowar
-    }
-
-    ship = {
-        name = "Victoria"
-        type = frigate
-    }
-
-    ship = {
-        name = "Nuestra Señora del Patrocinio"
-        type = frigate
-    }
-
-    ship = {
-        name= "1a Flotilla de Transporte"
-        type = clipper_transport
-    }
-
-    ship = {
-        name= "2a Flotilla de Transporte"
-        type = clipper_transport
-    }
-
-    ship = {
-        name= "3a Flotilla de Transporte"
-        type = clipper_transport
-    }
-}
-
-navy = {
-    name = "Armada Real Española"
-    location = 506
-    ship = {
-        name= "San Raimundo"
-        type = manowar
-    }
-
-    ship = {
-        name= "Héroe"
-        type = manowar
-    }
-
-    ship = {
-        name= "San Pablo"
-        type = manowar
-    }
-
-    ship = {
-        name= "Ceres"
-        type = frigate
-    }
-
-    ship = {
-        name= "Gloria"
-        type = frigate
-    }
-
-    ship = {
-        name= "Nuestra Señora de Asunción"
-        type = frigate
-    }
-
-    ship = {
-        name= "Nuestra Señora de Atocha"
-        type = frigate
-    }
-
-    ship = {
-        name= "Santa Sabina"
-        type = frigate
-    }
 
     ship = {
         name= "1a Flotilla de Transporte"

--- a/HPM/history/units/USA_oob.txt
+++ b/HPM/history/units/USA_oob.txt
@@ -363,7 +363,7 @@ navy = {
     }
 
     ship = {
-        name= "Pennsylvania"
+        name= "Independence"
         type = manowar
     }
 
@@ -373,7 +373,7 @@ navy = {
     }
 
     ship = {
-        name= "Columbia"
+        name= "Fairfield"
         type = frigate
     }
 
@@ -418,11 +418,6 @@ navy = {
     name = "4th Squadron"
     location = 219
     ship = {
-        name= "Independance"
-        type = frigate
-    }
-
-    ship = {
         name= "Brandywine"
         type = frigate
     }
@@ -447,32 +442,7 @@ navy = {
 navy = {
     name = "1st Reserve Squadron"
     location = 247
-    ship = {
-        name= "Alabama"
-        type = manowar
-    }
-
-    ship = {
-        name= "Vermont"
-        type = manowar
-    }
-
-    ship = {
-        name= "Virginia"
-        type = manowar
-    }
-
-    ship = {
-        name= "1st Reserve Transport"
-        type = clipper_transport
-    }
-
-}
-
-navy = {
-    name = "2nd Reserve Squadron"
-    location = 214
-    ship = {
+	ship = {
         name= "Columbus"
         type = manowar
     }
@@ -483,16 +453,16 @@ navy = {
     }
 
     ship = {
-        name= "New York"
-        type = manowar
-    }
-
-    ship = {
         name= "North Carolina"
         type = manowar
     }
 
     ship = {
+        name= "1st Reserve Transport"
+        type = clipper_transport
+    }
+	
+	ship = {
         name= "2nd Reserve Transport"
         type = clipper_transport
     }


### PR DESCRIPTION
Fixed the navies of the US, Spain and Portugal.

US
- 7 Man'o'wars
- 8 Frigates

Spain
- 3 Man'o'wars
- 3 Frigates
- 1 Troopship

Portugal
- 2 Man'o'wars
- 4 Frigates

https://www.academia.edu/35251769/THE_NAVIES_OF_THE_WORLD_1835_1840
http://felipe.mbnet.fi/index.html
https://en.wikipedia.org/wiki/SS_Royal_William