### PR TITLE
Really release Ezo when playing as them

### DIFF
--- a/HPM/events/JAPFlavor.txt
+++ b/HPM/events/JAPFlavor.txt
@@ -3010,6 +3010,15 @@ country_event = {
         EZO = { all_core = { remove_core = THIS } }
         release_vassal = EZO
         relation = { who = EZO value = 400 }
+        random_owned = {
+            limit = {
+                owner = { is_greater_power = yes }
+            }
+
+            owner = {
+                diplomatic_influence = { who = EZO value = 400 }
+            }
+        }
         ai_chance = { factor = 0.01 }
     }
     option = {
@@ -3017,8 +3026,17 @@ country_event = {
         EZO = { all_core = { remove_core = JAP remove_core = TKG } }
         all_core = { limit = { state_id = 1086 } remove_core = TKG remove_core = JAP add_core = EZO }
         any_owned = { limit = { is_core = EZO } secede_province = EZO }
+        release_vassal = EZO
         relation = { who = EZO value = 400 }
-        diplomatic_influence = { who = EZO value = 400 }
+        random_owned = {
+            limit = {
+                owner = { is_greater_power = yes }
+            }
+
+            owner = {
+                diplomatic_influence = { who = EZO value = 400 }
+            }
+        }
         change_tag_no_core_switch = EZO
         ai_chance = { factor = 0 }
     }


### PR DESCRIPTION
The final Ezo Republic event ([id 97682]) has a straightforward setup,
giving four options as to the fate of the republic.

First, the usual two choices between the personal land grab or keeping a
puppet around:

- don't agree to their request & release them, leaving them susceptible
  to be eaten since the island will still have Japanese cores
- agree to their request, keeping them as a puppet with Japanese cores

Then, the two choices between letting the puppet go or letting the
puppet go while also playing as them. The option comments & effects are
as follows:

- "Set them completely free", releasing & revoking own cores
- "Set them completely free and play as them", also revoking Japanese
  cores... while not releasing at all!

  https://github.com/arkhometha/Historical-Project-Mod/blob/d812ad33f897866fd38ee58a38a275dc8fe02554/HPM/events/JAPFlavor.txt#L3015-L3024

This change harmonises those last two options:

- really release Ezo in either case
- grant the same amount of diplomatic influence

Note that it was already possible for a player that starts as Japan to
switch to an independent Ezo without a save/reload or any trickery. Once
Ezo is on the map but before Japan decides its fate, a player can use
the GTFO decision to grant the island its independence. The final fate
event will still be eligible, letting the player revoke & switch
country.

[id 97682]: https://github.com/arkhometha/Historical-Project-Mod/blob/d812ad33f897866fd38ee58a38a275dc8fe02554/HPM/events/JAPFlavor.txt#L2974

---

This change has been (lightly) tested.