### PR TITLE
Colourful localisation

### DIFF
--- a/HPM/interface/core.gfx
+++ b/HPM/interface/core.gfx
@@ -627,6 +627,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	############################
@@ -644,6 +656,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 
@@ -739,6 +763,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	
@@ -778,6 +814,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	
@@ -990,6 +1038,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	
@@ -1012,6 +1072,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}		
 	}
 	
@@ -1027,6 +1099,18 @@ bitmapfonts = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}		
 	}
 	
@@ -1056,6 +1140,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	
@@ -1078,6 +1174,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	bitmapfont = {
@@ -1109,6 +1217,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 bitmapfont = {
@@ -1130,6 +1250,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 	bitmapfont = {
@@ -1157,6 +1289,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 bitmapfont = {
@@ -1178,6 +1322,18 @@ bitmapfont = {
 			b = { 0 0 0 }
 			g = { 176 176 176 }
 			Y = { 255 189 0 }
+			F = { 219 138 59 }		#Fire Bush (Yellow)
+			y = { 199 191 125 }		#Yuma (Yellow)
+			S = { 133 255 81 }		#Screamin' Green
+			h = { 56 105 48 }		#Green House
+			d = { 0 148 255 }		#Dodger Blue
+			m = { 97 209 250 }		#Maya Blue
+			f = { 66 94 194 }		#Free Speech Blue
+			p = { 161 31 153 }		#Dark Purple
+			v = { 243 81 255 }		#Heliotrope	(Violet)
+			V = { 216 30 5 }		#Venetian Red
+			u = { 125 41 31 }		#Burnt Umber (Brown)
+			s = { 148 130 110 }		#Squirrel (Brown)
 		}
 	}
 bitmapfont = {


### PR DESCRIPTION
Added 12 new colours that can be used to change the colour of localisations.

Now the different conditions can have different colours to improve readability.

Here are the all the colours that currently can be used. The first 7 are from vanilla and the rest are the new ones.

![tooltip](https://user-images.githubusercontent.com/59878301/80892782-6f36b380-8cd5-11ea-8985-e0deb4f5608d.png)


![event](https://user-images.githubusercontent.com/59878301/80892787-7493fe00-8cd5-11ea-8309-7403d98fa65b.png)

And here are some examples on how they can be used

![example2](https://user-images.githubusercontent.com/59878301/80892792-7b227580-8cd5-11ea-942e-bd7b51cd5269.png)


![example1](https://user-images.githubusercontent.com/59878301/80892796-85dd0a80-8cd5-11ea-8332-34ca74d138d7.png)

Of course more colours can be added.
