### PR TITLE
Natives Status decisions compatible with accepted cultures

### DIFF
--- a/HPM/decisions/Segregation.txt
+++ b/HPM/decisions/Segregation.txt
@@ -81,7 +81,7 @@ political_decisions = {
                 all_core = {
                     owned_by = THIS
                     is_colonial = no
-                    any_pop = { is_primary_culture = yes }
+                    any_pop = { is_accepted_culture = yes }
                 }
                 nationalvalue = nv_equality
             }
@@ -259,7 +259,7 @@ political_decisions = {
             all_core = {
                 owned_by = THIS
                 is_colonial = no
-                any_pop = { is_primary_culture = yes }
+                any_pop = { is_accepted_culture = yes }
             }
             OR = {
                 upper_house = { ideology = reactionary value = 0.4 }
@@ -375,7 +375,7 @@ political_decisions = {
             all_core = {
                 owned_by = THIS
                 is_colonial = no
-                any_pop = { is_primary_culture = yes }
+                any_pop = { is_accepted_culture = yes }
             }
             OR = {
                 upper_house = { ideology = reactionary value = 0.51 }


### PR DESCRIPTION
If you are playing as The United States, you'll probably end up with some provinces in the south/Texas without any Yankees to fulfill the conditions. Sometimes even Alaska provinces will flip to Dixie only. It's really hard to get any internal immigration for these provinces, trying to force craftsmen pops migration closing factories will only work with single province states. 

Decisions now can be enacted when there is at least 1 accepted culture pop in the province, instead of primary culture only.