### PR TITLE
Minor fixes

### DIFF
--- a/HPM/decisions/NationalUnification.txt
+++ b/HPM/decisions/NationalUnification.txt
@@ -927,6 +927,7 @@ political_decisions = {
                         province_id = 1303
                         province_id = 1312
                         province_id = 1320
+						province_id = 2591
                         is_core = KAL
                         is_core = MAK
                         is_core = AFG

--- a/HPM/decisions/New Colonies.txt
+++ b/HPM/decisions/New Colonies.txt
@@ -3068,13 +3068,10 @@ political_decisions = {
             machine_guns = 1
             market_regulations = 1
             OR = {
-                ENG_2036 = { owned_by = THIS }
-                ENG_2044 = { owned_by = THIS }
-            }
-            OR = {
-                ENG_2036 = { owned_by = THIS }
-                ENG_2039 = { owned_by = THIS }
-            }
+				owns = 2045
+				ENG_2044 = { owned_by = THIS }
+				ENG_2039 = { owned_by = THIS }
+			}
         }
 
         effect = {

--- a/HPM/decisions/Turkestan.txt
+++ b/HPM/decisions/Turkestan.txt
@@ -220,7 +220,10 @@ political_decisions = {
                         primary_culture = tajik
                         primary_culture = kazak
                     }
-                    in_sphere = THIS
+					OR = {
+						in_sphere = THIS
+						vassal_of = THIS
+					}
                     NOT = { tag = THIS }
                 }
                 annex_to = THIS


### PR DESCRIPTION
-Forming India doesn't require Tranquebar which is owned by Denmark at the beginning of the game

-The organise_tanzania decision can't be taken by a tag that only owns the province of Zanzibar. This will avoid situations where for example the UK takes the decision by simply owning Zanzibar while the entire coast and mainland is owned by another GP

-The tag that unites Turkestan now inherits its appropriate puppets