### PR TITLE
free_botswana and Lourenco Marques fixes

### DIFF
--- a/HPM/decisions/New Colonies.txt
+++ b/HPM/decisions/New Colonies.txt
@@ -7073,7 +7073,8 @@ political_decisions = {
         }
 
         effect = {
-            release_vassal = TSW
+            release = TSW
+            create_vassal = TSW
             relation = { who = TSW value = 400 }
             diplomatic_influence = { who = TSW value = 400 }
         }

--- a/HPM/events/PORFlavor.txt
+++ b/HPM/events/PORFlavor.txt
@@ -972,7 +972,7 @@ country_event = {
             secede_province = THIS
             change_province_name = "Manjacaze"
         }
-        2051 = { state_scope = { change_region_name = "Lourenço Marques" } }
+        2050 = { state_scope = { change_region_name = "Lourenço Marques" } }
     }
 }
 


### PR DESCRIPTION
1. Free Botswana decision - `release_vassal = TSW` requires them to be a vassal already to release from that status. Use
`release = TSW
create_vassal = TSW`

2. #Getting Lourenço Marques event - although not an error, it would be better to scope to the state from a province already checked in the trigger - 2049 or 2050 instead of 2051