### PR TITLE
Correct occurrences of formerly colonial MOS to BKF

### DIFF
--- a/HPM/events/New Colonies.txt
+++ b/HPM/events/New Colonies.txt
@@ -3010,7 +3010,7 @@ province_event = {
                     NOT = { is_core = MLI }
                 }
                 add_core = MLI
-                remove_core = MOS
+                remove_core = BKF
                 any_pop = { militancy = -3 }
             }
         }
@@ -3060,7 +3060,7 @@ province_event = {
                     NOT = { is_core = MLI }
                 }
                 add_core = MLI
-                remove_core = MOS
+                remove_core = BKF
                 any_pop = { militancy = -3 }
             }
         }
@@ -3203,7 +3203,7 @@ province_event = {
         NOT = {
             is_core = MLI
             1901 = { owned_by = THIS }
-            MOS = {
+            BKF = {
                 vassal_of = THIS
                 is_culture_group = THIS
             }
@@ -3222,7 +3222,7 @@ province_event = {
                     NOT = { is_core = MLI }
                 }
                 add_core = MLI
-                remove_core = MOS
+                remove_core = BKF
                 any_pop = { militancy = -3 }
             }
         }
@@ -3757,24 +3757,23 @@ province_event = {
         owned_by = THIS
         controlled_by = THIS
         any_neighbor_province = {
-            is_core = MOS
+            is_core = BKF
         }
         owner = {
             civilized = yes
-            has_global_flag = burkina_faso_organized
             NOT = { capital_scope = { continent = africa } }
         }
         OR = {
             AND = {
                 owner = { owns = 1901 }
-                MOS = { exists = no }
+                BKF = { exists = no }
             }
-            MOS = {
+            BKF = {
                 vassal_of = THIS
             }
         }
         NOT = {
-            is_core = MOS
+            is_core = BKF
         }
     }
 
@@ -3787,9 +3786,9 @@ province_event = {
         state_scope = {
             any_owned = {
                 limit = {
-                    NOT = { is_core = MOS }
+                    NOT = { is_core = BKF }
                 }
-                add_core = MOS
+                add_core = BKF
                 remove_core = MLI
                 any_pop = { militancy = -3 }
             }
@@ -3810,19 +3809,18 @@ province_event = {
         owned_by = THIS
         controlled_by = THIS
         any_neighbor_province = {
-            is_core = MOS
+            is_core = BKF
         }
         owner = {
             civilized = yes
-            has_global_flag = burkina_faso_organized
             NOT = { capital_scope = { continent = africa } }
         }
         OR = {
             AND = {
                 owner = { owns = 1901 }
-                MOS = { exists = no }
+                BKF = { exists = no }
             }
-            MOS = {
+            BKF = {
                 vassal_of = THIS
             }
         }
@@ -3845,9 +3843,9 @@ province_event = {
         state_scope = {
             any_owned = {
                 limit = {
-                    NOT = { is_core = MOS }
+                    NOT = { is_core = BKF }
                 }
-                add_core = MOS
+                add_core = BKF
                 remove_core = MLI
                 any_pop = { militancy = -3 }
             }


### PR DESCRIPTION
At some point `MOS` was doing double duty as both a native and colonial
country. This was superseded by the use of `BKF` as a strictly colonial
country.

This change updates some old code to correctly refer to `BKF` cores
following organisation of the region. A review suggests that all
remaining `MOS`/`BKF` occurrences properly respect the native/colonial
separation.

---

I did not test this change.