### PR TITLE
Exclude the Arab Union from losing Mashriqi

### DIFF
--- a/HPM/events/Independence.txt
+++ b/HPM/events/Independence.txt
@@ -2391,6 +2391,7 @@ country_event = {
             exists = IRQ
             has_country_flag = no_iraq_independence
             primary_culture = mashriqi
+            tag = ARU
         }
         is_possible_vassal = IRQ
         revolution_n_counterrevolution = 1


### PR DESCRIPTION
The Arab Union is set up as quasi-culture union, and so should not lose
Mashriqi even when formed by another culture from the group.